### PR TITLE
Add paml dependency and remove /nfs path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository is provided primarily for citation of this software.  We do not 
 - smalt  0.7.6
 - samtools (bcftools & htslib) 1.2 _or_ 1.6
 - ssaha2  2.5.5
+- paml  4.9
 
 
 ## Install

--- a/modules/Si_nexus.py
+++ b/modules/Si_nexus.py
@@ -1778,7 +1778,7 @@ def parsimonious_sequence_reconstruction(treeObject, alignmentObject, transforma
 		
 		#run paml
 		
-		os.system("/nfs/users/nfs_m/mh10/software/paml41/bin/baseml > "+tmpname+"temp.tmp")
+		os.system("baseml > "+tmpname+"temp.tmp")
 	
 		#remove spaces from rst alignment (necessary to allow easier reading of tree and ancestral sequences
 		


### PR DESCRIPTION
A dependency was still included as a hard-coded /nfs path in one module. Added the dependency to readme and replaced path with executable name.